### PR TITLE
Dockerize and add docker-compose file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7-apache
+
+RUN apt-get update && apt-get install -y git unzip locales
+RUN docker-php-ext-install mysqli pdo_mysql gettext
+
+WORKDIR /var/www/html
+COPY . .
+
+RUN php composer.phar install -o
+
+RUN chown -R www-data:www-data . && \
+  find . -type d -print0 | xargs -0 chmod 555 && \
+  find . -type f -print0 | xargs -0 chmod 444 && \
+  find data -type d -print0 | xargs -0 chmod 755 && \
+  find data -type f -print0 | xargs -0 chmod 644 && \
+  chmod 755 .
+
+RUN echo "de_DE.UTF-8 UTF-8" >> /etc/locale.gen && \
+  echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
+  locale-gen

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+services:
+  partdb:
+    build: .
+    ports:
+      - "80:80"
+    depends_on:
+      - database
+    volumes:
+      - partdb-data:/var/www/html/data
+    restart: always
+
+  database:
+    image: mariadb:latest
+    volumes:
+      - partdb-database:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: foobar
+      MYSQL_DATABASE: partdb
+    restart: always
+
+volumes:
+  partdb-database:
+  partdb-data:


### PR DESCRIPTION
Related: https://github.com/Part-DB/Part-DB/issues/14

This PR adds a Dockerfile to build a docker image of PartDB itself and a docker-compose file to bring up a PartDB server complete with database.

The Dockerfile is based on [`php:7-apache`](https://hub.docker.com/_/php/). While I could not get this to work on the `nextgen` branch (the database schema seems to have problems), I have successfully tested it on the `v0.4.6` tag.

The `docker-compose.yml` uses [MariaDB](https://hub.docker.com/_/mariadb/) as database.
When configuring PartDB for the first time, configure the database as follows:
* host: `database`
* database: `partdb`
* user: `root`
* password: `foobar`