### PR TITLE
Libonig-dev missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7-apache
 
-RUN apt-get update && apt-get install -y git unzip locales curl pkg-config libcurl4-openssl-dev zlib1g-dev libicu-dev g++
+RUN apt-get update && apt-get install -y git unzip locales curl pkg-config libcurl4-openssl-dev zlib1g-dev libicu-dev g++ libonig-dev
 RUN docker-php-ext-install mysqli pdo_mysql gettext curl intl mbstring
 
 WORKDIR /var/www/html


### PR DESCRIPTION
To be able to compile the current source against the Dockerfile libonig-dev is missing.

Anyways, i currently compile ARM builds every night:
https://hub.docker.com/r/makehackswork/part-db

Tested against

- RaspberryPi4
- RaspberryPi3
- RaspberryPi Zero
- Banana Pi W2