### PR TITLE
Implement code for basic kicad import

### DIFF
--- a/templates/nextgen/edit_devices.php/smarty_edit_devices.tpl
+++ b/templates/nextgen/edit_devices.php/smarty_edit_devices.tpl
@@ -11,7 +11,7 @@
         {t}Baugruppen{/t}
     </div>
     <div class="card-body">
-        <form action="" method="post" class="row no-progbar">
+        <form action="" method="post" class="row no-progbar" enctype="multipart/form-data">
             <div class="col-md-4">
 
                 {if !isset($id) || $id == 0}
@@ -87,6 +87,13 @@
                                     <textarea name="comment" class="form-control" rows="5" {if !$can_edit}disabled{/if}
                                               placeholder="{t}z.B. wichtige Links{/t}">{if isset($comment)}{$comment}{/if}</textarea>
                                     <p class="form-text text-muted">{t}Hinweis: Hier kann BBCode verwendet werden um den Text besonders auszuzeichnen (z.B. [b]Fett[/b]).{/t}</p>
+                                </div>
+                            </div>
+
+                            <div class="form-group row">
+                                <label class="col-form-label col-md-3">{t}XML File:{/t}</label>
+                                <div class="col-md-9">
+                                    <p class="form-control-plaintext"><input type="file" name="fileToUpload" id="fileToUpload" accept=".xml" {if !$can_edit}disabled{/if}></p>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
This implements some basic kicad device import function.

The kicad project must assign the part id to each element in the schematic and create the bom. With the bom kicad creates an xml file which contains all the parts on the board and every field from those parts.
The new xml file upload in the "Create device" window accept this xml file and will create a the device with every part in the schematic.

If a part doesn't have a id field, the upload will fail in the current version.

This code is currently experimental and not fully tested with invalid xml files. Only the import of a simple kicad example project was done.

I dont know which branch should contain experimental code so i used the master branch.